### PR TITLE
Allocate empty object when doing ethereum login

### DIFF
--- a/routes/api/eth/auth.js
+++ b/routes/api/eth/auth.js
@@ -11,6 +11,7 @@ module.exports = (api) => {
     const mnemonicWallet = api.eth._keys(seed, true);
 
     api.eth.wallet = mnemonicWallet;
+    api.eth.connect = {};
 
     for (let key in api.eth.coins) {
       const network = key.toLowerCase().indexOf('ropsten') > -1 ? 'ropsten' : 'homestead';


### PR DESCRIPTION
When adding an ethereum coin, 0 balance is shown in a wallet, and an error message is shown in the console. The error message is that is tried to add a property to api.eth.connect when it contains a null value. For avoiding this situation, api.eth.connect must be assigned to an empty object when starting to work with a Ethereum wallet, this is, at login.